### PR TITLE
Reset the theme on special pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+### Changed
+- Reset the theme on special pages like the new tab page, where we can't detect
+a color
+
+## 0.1.0 - 2018-04-03
+### Added
+- Initial implementation
+
+[Unreleased]: https://github.com/dguo/color-tailor/compare/v0.1.0...HEAD

--- a/src/background.js
+++ b/src/background.js
@@ -57,13 +57,22 @@ async function saveTheme(message, sender) {
     }
 }
 
-function handleTabActivated(activeInfo) {
+async function handleTabActivated(activeInfo) {
     const theme = themes[activeInfo.tabId];
 
     if (theme) {
         browser.theme.update(activeInfo.windowId, theme);
     } else {
-        browser.tabs.sendMessage(activeInfo.tabId, null);
+        try {
+            await browser.tabs.sendMessage(activeInfo.tabId, null);
+        } catch (error) {
+            /* We expect to end up here when the tab is not a normal page,
+               such as the new tab page or a page that is not allowed to run
+               content scripts (like addons.mozilla.org).
+               See https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Content_scripts
+               */
+            browser.theme.reset();
+        }
     }
 }
 


### PR DESCRIPTION
Currently, the theme stays the same, depending on the user's previous tab.

Resolves #1.